### PR TITLE
Fix handling of `None` case

### DIFF
--- a/namedstruct/message.py
+++ b/namedstruct/message.py
@@ -210,7 +210,12 @@ class Message(object):
         msg = self._tuple._make([None] * len(self._tuple._fields))
         for elem in self._elements.values():
             if isinstance(elem, ElementDiscriminated):
-                val = elem.format[kwargs[elem.ref]].make(kwargs[elem.name])
+                if elem.format[kwargs[elem.ref]]:
+                    val = elem.format[kwargs[elem.ref]].make(kwargs[elem.name])
+                else:
+                    # `None` does not have a `.make()` function
+                    # so set the value to None
+                    val = None
                 msg = msg._replace(**dict([(elem.name, val)]))
             elif isinstance(elem, ElementVariable):
                 val = [elem.format.make(e) for e in kwargs[elem.name]]


### PR DESCRIPTION
If you have a struct like:

``` python
my_struct = namedstruct.Message('example', [
  ('data', {
    this.thing: OtherSizedByte,
    this.other_thing: RegularByte,
    this.none_thing: None,
  }, 'data_id'),
])
```

When you try and use the `this.none_thing`, you'll get this error.

```
    def make(self, obj=None, **kwargs):
        """
            A utility function that returns a namedtuple based on the current
            object's format for the supplied object.
            """
        if obj is not None:
            if isinstance(obj, dict):
                kwargs = obj
            elif isinstance(obj, tuple):
                kwargs = obj._asdict()
        msg = self._tuple._make([None] * len(self._tuple._fields))
        for elem in self._elements.values():
            if isinstance(elem, ElementDiscriminated):
>               val = elem.format[kwargs[elem.ref]].make(kwargs[elem.name])
E               AttributeError: 'NoneType' object has no attribute 'make'
```

I think this fixes it by not calling `make` on the `None` object.
