### PR TITLE
Add a length attribute for message

### DIFF
--- a/namedstruct/message.py
+++ b/namedstruct/message.py
@@ -1,6 +1,7 @@
 """NamedStruct class."""
 
 import collections
+import struct
 import namedstruct.modes
 from namedstruct.element import Element
 
@@ -215,3 +216,22 @@ class Message(object):
             val = self._elements[field].make(kwargs)
             msg = msg._replace(**dict([(field, val)]))
         return msg
+
+    def __len__(self):
+        if self._elements == {}:
+            return 0
+
+        size = 0
+        for val in self._elements.values():
+            if isinstance(val.format, (bytes, str)):
+                size += struct.calcsize(val.format)
+            elif isinstance(val.format, (dict, )):
+                lengths = {len(item) for item in val.format.values()}
+                if len(lengths) > 1:
+                    raise AttributeError('Unable to calculate size due to differing size sub items')
+
+                size += sum(lengths)
+            else:
+                size += len(val.format)
+
+        return size

--- a/namedstruct/test/test_length.py
+++ b/namedstruct/test/test_length.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import enum
+import struct
+import unittest
+
+from namedstruct.message import Message
+
+
+class MyEnum(enum.Enum):
+    """Possible enum types."""
+    THIS = 0
+    THAT = 1
+    OTHER = 2
+
+
+MyNamed = Message('MyNamed', [
+    ('type', 'B'),
+    ('name', '32s'),
+])
+
+MyOtherNamed = Message('MyOtherNamed', [
+    ('first', 'B'),
+    ('second', 'H'),
+    ('pad', '30x'),
+])
+
+NotSameMessage = Message('WowNotEvenClose', [
+    ('first_and_only', '4H')
+])
+
+
+class TestLengthHelper(unittest.TestCase):
+    """Test the length for this class"""
+    def test_empty_length(self):
+        empty_message = Message('Empty', [])
+        assert len(empty_message) == 0
+
+    def test_single_item(self):
+        one_message = Message('One', [
+            ('info', 'H'),
+        ])
+        assert len(one_message) == struct.calcsize('H')
+
+    def test_comparison(self):
+        assert len(MyNamed) == len(MyOtherNamed)
+        assert len(MyNamed) != len(NotSameMessage)
+
+    def test_bad_length_item(self):
+        bad_message = Message('BadMessage', [
+            ('type', 'B', MyEnum),
+            ('data', {
+                MyEnum.THIS: MyNamed,
+                MyEnum.THAT: NotSameMessage,
+                MyEnum.OTHER: MyOtherNamed,
+            }, 'type'),
+        ])
+
+        with self.assertRaises(AttributeError):
+            print(len(bad_message))
+
+    def test_long_item(self):
+        long_message = Message('ThisIsALongOne', [
+            ('ID', 'B'),
+            ('delay', 'B'),
+            ('a_byte', 'B'),
+            ('type', 'B', MyEnum),
+            ('data', {
+                MyEnum.THIS: MyNamed,
+                MyEnum.THAT: MyNamed,
+                MyEnum.OTHER: MyOtherNamed,
+            }, 'type'),
+        ])
+
+        # Second size is from the MyNamed Enum above
+        my_named_format = 'B32s'
+        assert len(long_message) == struct.calcsize('BBBB' + my_named_format)
+
+    def test_variable_length(self):
+        dont_know_how_to_test = Message('DontKnow', [
+            ('numNames', 'B', 'names'),
+            ('names', MyNamed, 'numNames'),
+        ])
+
+        # Not sure how to test this one yet
+        # could do some multiples thing or just let it be.
+        if False:
+            print(len(dont_know_how_to_test))


### PR DESCRIPTION
I wanted to be able to do something like:

```
MyMessage = Messsage(...)
MyOther = Message(...)

assert len(MyMessage) == len(MyOther)
```

So when we have messages that are in the same area (in the case of a `union`) then I can know they are the same length, or be alerted to it if one of them changes.
