### PR TITLE
Improve caching on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 cache:
   pip: true
   directories:
-    - env
+    - ~/virtualenv/python3.5.*
 
 env:
   global:

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,11 @@ else
 endif
 
 # Virtual environment paths
-ENV := env
+ifdef TRAVIS
+	ENV := $(shell dirname $(shell dirname $(shell which $(SYS_PYTHON))))/
+else
+	ENV := env
+endif
 ifneq ($(findstring win32, $(PLATFORM)), )
 	BIN := $(ENV)/Scripts
 	ACTIVATE := $(BIN)/activate.bat
@@ -49,14 +53,11 @@ else
 endif
 
 # Virtual environment executables
-ifndef TRAVIS
-	BIN_ := $(BIN)/
-endif
-PYTHON := $(BIN_)python
-PIP := $(BIN_)pip
-EASY_INSTALL := $(BIN_)easy_install
-SNIFFER := $(BIN_)sniffer
-HONCHO := $(ACTIVATE) && $(BIN_)honcho
+PYTHON := $(BIN)/python
+PIP := $(BIN)/pip
+EASY_INSTALL := $(BIN)/easy_install
+SNIFFER := $(BIN)/sniffer
+HONCHO := $(ACTIVATE) && $(BIN)/honcho
 
 # MAIN TASKS ###################################################################
 
@@ -118,10 +119,10 @@ $(PYTHON):
 
 # CHECKS #######################################################################
 
-PEP8 := $(BIN_)pep8
-PEP8RADIUS := $(BIN_)pep8radius
-PEP257 := $(BIN_)pep257
-PYLINT := $(BIN_)pylint
+PEP8 := $(BIN)/pep8
+PEP8RADIUS := $(BIN)/pep8radius
+PEP257 := $(BIN)/pep257
+PYLINT := $(BIN)/pylint
 
 .PHONY: check
 check: pep8 pylint ## Run linters and static analysis
@@ -144,9 +145,9 @@ fix: install
 
 # TESTS ########################################################################
 
-PYTEST := $(BIN_)py.test
-COVERAGE := $(BIN_)coverage
-COVERAGE_SPACE := $(BIN_)coverage.space
+PYTEST := $(BIN)/py.test
+COVERAGE := $(BIN)/coverage
+COVERAGE_SPACE := $(BIN)/coverage.space
 
 RANDOM_SEED ?= $(shell date +%s)
 
@@ -188,9 +189,9 @@ read-coverage:
 
 # DOCUMENTATION ################################################################
 
-PYREVERSE := $(BIN_)pyreverse
-PDOC := $(PYTHON) $(BIN_)pdoc
-MKDOCS := $(BIN_)mkdocs
+PYREVERSE := $(BIN)/pyreverse
+PDOC := $(PYTHON) $(BIN)/pdoc
+MKDOCS := $(BIN)/mkdocs
 
 PDOC_INDEX := docs/apidocs/$(PACKAGE)/index.html
 MKDOCS_INDEX := site/index.html
@@ -227,8 +228,8 @@ mkdocs-live: mkdocs ## Launch and continuously rebuild the mkdocs site
 
 # BUILD ########################################################################
 
-PYINSTALLER := $(BIN_)pyinstaller
-PYINSTALLER_MAKESPEC := $(BIN_)pyi-makespec
+PYINSTALLER := $(BIN)/pyinstaller
+PYINSTALLER_MAKESPEC := $(BIN)/pyi-makespec
 
 DIST_FILES := dist/*.tar.gz dist/*.whl
 EXE_FILES := dist/$(PROJECT).*
@@ -255,7 +256,7 @@ $(PROJECT).spec:
 
 # RELEASE ######################################################################
 
-TWINE := $(BIN_)twine
+TWINE := $(BIN)/twine
 
 .PHONY: register
 register: dist ## Register the project on PyPI


### PR DESCRIPTION
This PR updates the tooling to directly use the binaries created in the Travis CI virtual environment and cache those files between builds.

