### PR TITLE
Elem none

### DIFF
--- a/starstruct/elementcallable.py
+++ b/starstruct/elementcallable.py
@@ -3,6 +3,8 @@ Element callable.
 
 Call a function to validate data.
 
+TODO: Update the format here
+
 .. code-block:: python
 
     from binascii import crc32
@@ -99,7 +101,6 @@ class ElementCallable(Element):
     :param mode: The mode in which to pack the bytes
     :param alignment: Number of bytes to align to
     """
-
     # pylint: disable=too-many-instance-attributes
     def __init__(self, field: list, mode: Optional[Mode]=Mode.Native, alignment: Optional[int]=1):
         # All of the type checks have already been performed by the class
@@ -108,19 +109,33 @@ class ElementCallable(Element):
 
         # Callable elements use the normal struct packing method
         self.format = field[1]
-        self._func_ref = field[2]
-        self._func_args = field[3]
 
-        if len(field) == 5:
-            self._error_on_bad_result = field[4]
+        if isinstance(field[2], dict):
+            self.ref = field[2]
+
+            self._make_func = self.ref['make'][0]
+            self._make_args = self.ref['make'][1:]
+
+            self._pack_func = self.ref['pack'][0]
+            self._pack_args = self.ref['pack'][1:]
+
+            self._unpack_func = self.ref['unpack'][0]
+            self._unpack_args = self.ref['unpack'][1:]
+        elif isinstance(field[2], set):
+            instruction = field[2].copy().pop()
+            self.ref = {'all': instruction}
+
+            self._make_func = self._pack_func = self._unpack_func = instruction[0]
+            self._make_args = self._pack_args = self._unpack_args = instruction[1:]
+
+        if len(field) == 4:
+            self._error_on_bad_result = field[3]
         else:
             self._error_on_bad_result = True
 
         self._elements = []
 
         self.update(mode, alignment)
-
-        self._elements = []
 
     @property
     def _struct(self):
@@ -133,11 +148,19 @@ class ElementCallable(Element):
 
         :param field: The items to determine the structure of the element
         """
-        return len(field) >= 4 \
-            and isinstance(field[0], str) \
-            and isinstance(field[1], str) \
-            and callable(field[2]) \
-            and isinstance(field[3], list)
+        required_keys = {'pack', 'unpack', 'make'}
+
+        if len(field) >= 3 and isinstance(field[0], str) and isinstance(field[1], str):
+            if isinstance(field[2], dict):
+                if set(field[2].keys()) == required_keys and \
+                        all(isinstance(val, tuple) for val in field[2].values()):
+                    return True
+            elif isinstance(field[2], set):
+                return len(field[2]) == 1 and \
+                    all(isinstance(val, tuple) for val in field[2])
+
+        return False
+
 
     def validate(self, msg):
         """
@@ -146,10 +169,17 @@ class ElementCallable(Element):
 
         All elements that are Variable must reference valid Length elements.
         """
-        if not all(k in msg
-                   for k in [arg if isinstance(arg, str) else arg.decode('utf-8')
-                             for arg in self._func_args]):
-            raise ValueError('Need all keys to be in the message')
+        for action in self.ref.values():
+            for arg in action[1:]:
+                if isinstance(arg, str):
+                    pass
+                elif hasattr(arg, 'decode'):
+                    arg = arg.decode('utf-8')
+                elif hasattr(arg, 'to_bytes'):
+                    arg = arg.to_bytes((arg.bit_length() + 7) // 8, self._mode.to_byteorder()).decode('utf-8')
+
+                if arg not in msg:
+                    raise ValueError('Need all keys to be in the message, {0} was not found\nAction: {1} -> {2}'.format(arg, action, action[1]))
 
     def update(self, mode=None, alignment=None):
         """change the mode of the struct format"""
@@ -161,18 +191,18 @@ class ElementCallable(Element):
 
     def pack(self, msg):
         """Pack the provided values into the supplied buffer."""
-        packer = self.make(msg)
+        pack_values = self.call_func(msg, self._pack_func, self._pack_args)
 
         # Test if the object is iterable
         # If it isn't, then turn it into a list
         try:
-            _ = (p for p in packer)
+            _ = (p for p in pack_values)
         except TypeError:
-            packer = [packer]
+            pack_values = [pack_values]
 
         # Unpack the items for struct to allow for mutli-value
         # items to be passed in.
-        return self._struct.pack(*packer)
+        return self._struct.pack(*pack_values)
 
     def unpack(self, msg, buf):
         """Unpack data from the supplied buffer using the initialized format."""
@@ -190,7 +220,7 @@ class ElementCallable(Element):
             # for errors correctly.
             temp_dict = copy.deepcopy(msg._asdict())
             temp_dict.pop(self.name)
-            expected_value = self.make(temp_dict)
+            expected_value = self.call_func(msg, self._unpack_func, self._unpack_args)
 
             # Check for an error
             if expected_value != ret:
@@ -211,9 +241,25 @@ class ElementCallable(Element):
                 and msg[self.name] is not None:
             return msg[self.name]
 
+        ret = self.call_func(msg, self._make_func, self._make_args)
+
+        if self.name in msg:
+            if ret != msg[self.name]:
+                raise ValueError('Excepted value: {0}, but got: {1}'.format(ret, msg[self.name]))
+
+        return ret
+
+    def call_func(self, msg, func, args):
+        items = self.prepare_args(msg, args)
+        return func(*items)
+
+    def prepare_args(self, msg, args):
         items = []
 
-        for reference in self._func_args:
+        if hasattr(msg, '_asdict'):
+            msg = msg._asdict()
+
+        for reference in args:
             if isinstance(reference, str):
                 index = reference
                 attr = 'make'
@@ -227,10 +273,4 @@ class ElementCallable(Element):
                 getattr(self._elements[index], attr)(msg)
             )
 
-        ret = self._func_ref(*items)
-
-        if self.name in msg:
-            if ret != msg[self.name]:
-                raise ValueError('Excepted value: {0}, but got: {1}'.format(ret, msg[self.name]))
-
-        return ret
+        return items

--- a/starstruct/elementcallable.py
+++ b/starstruct/elementcallable.py
@@ -177,9 +177,10 @@ class ElementCallable(Element):
     def unpack(self, msg, buf):
         """Unpack data from the supplied buffer using the initialized format."""
         ret = self._struct.unpack_from(buf)
-        if isinstance(ret, (list, tuple)):
-            # TODO: I don't know if there is a case where we want to keep
-            # it as a list... but for now I'm just going to do this
+        if isinstance(ret, (list, tuple)) and len(ret) == 1:
+            # We only change it not to a list if we expected one value.
+            # Otherwise, we keep it as a list, because that's what we would
+            # expect (like for a 16I type of struct
             ret = ret[0]
 
         # Only check for errors if they haven't told us not to

--- a/starstruct/elementcallable.py
+++ b/starstruct/elementcallable.py
@@ -92,6 +92,7 @@ from starstruct.element import register, Element
 from starstruct.modes import Mode
 
 
+# pylint: disable=too-many-instance-attributes
 @register
 class ElementCallable(Element):
     """
@@ -103,7 +104,6 @@ class ElementCallable(Element):
     """
     accepted_mesages = (True, False)
 
-    # pylint: disable=too-many-instance-attributes
     def __init__(self, field: list, mode: Optional[Mode]=Mode.Native, alignment: Optional[int]=1):
         # All of the type checks have already been performed by the class
         # factory
@@ -163,7 +163,6 @@ class ElementCallable(Element):
                     all(isinstance(val, tuple) for val in field[2])
 
         return False
-
 
     def validate(self, msg):
         """

--- a/starstruct/elementcallable.py
+++ b/starstruct/elementcallable.py
@@ -161,7 +161,18 @@ class ElementCallable(Element):
 
     def pack(self, msg):
         """Pack the provided values into the supplied buffer."""
-        return self._struct.pack(self.make(msg))
+        packer = self.make(msg)
+
+        # Test if the object is iterable
+        # If it isn't, then turn it into a list
+        try:
+            _ = (p for p in packer)
+        except TypeError:
+            packer = [packer]
+
+        # Unpack the items for struct to allow for mutli-value
+        # items to be passed in.
+        return self._struct.pack(*packer)
 
     def unpack(self, msg, buf):
         """Unpack data from the supplied buffer using the initialized format."""

--- a/starstruct/elementnone.py
+++ b/starstruct/elementnone.py
@@ -1,0 +1,62 @@
+"""
+Element None
+
+A non-packable, non-unpackable item that can help facilitate with additional information about an object,
+pass extra references to a variable and potentially more
+
+.. code-block:: python
+
+    ExampleMessage = Message('VarTest', [('x', 'B'), ('y', 'B')])
+
+    CRCedMessage = Message('CRCedMessage', [
+       ('data', ExampleMessage),                  # A data field that has the example message in it
+       ('extra_param', None),                     # The None Element
+       ('crc', 'I', my_crc32, ['data', 'extra_param']),          # Crc the data, and give an error if we have something unexpected
+   ])
+
+"""
+
+from typing import Optional
+
+from starstruct.element import register, Element
+from starstruct.modes import Mode
+
+@register
+class ElementNone(Element):
+    """
+    Initialize a StarStruct element object.
+
+    :param field: The fields passed into the constructor of the element
+    :param mode: The mode in which to pack the bytes
+    :param alignment: Number of bytes to align to
+    """
+    def __init__(self, field: list, mode: Optional[Mode]=Mode.Native, alignment: Optional[int]=1):
+        self.name = field[0]
+
+        self.update(mode=mode, alignment=alignment)
+
+    @staticmethod
+    def valid(field: tuple) -> bool:
+        return len(field) == 2 \
+            and isinstance(field[0], str) \
+            and field[1] is None
+
+    def validate(self, msg):
+        return True
+
+    def update(self, mode=None, alignment=None):
+        if mode:
+            self._mode = mode
+
+        if alignment:
+            self._alignment = alignment
+        return
+
+    def pack(self, msg):
+        return b''
+
+    def unpack(self, msg, buf):
+        return (msg, buf)
+
+    def make(self, msg):
+        return msg[self.name]

--- a/starstruct/elementnone.py
+++ b/starstruct/elementnone.py
@@ -57,7 +57,7 @@ class ElementNone(Element):
         return b''
 
     def unpack(self, msg, buf):
-        return (msg, buf)
+        return (None, buf)
 
     def make(self, msg):
         return msg[self.name]

--- a/starstruct/elementnone.py
+++ b/starstruct/elementnone.py
@@ -21,6 +21,7 @@ from typing import Optional
 from starstruct.element import register, Element
 from starstruct.modes import Mode
 
+
 @register
 class ElementNone(Element):
     """

--- a/starstruct/elementvariable.py
+++ b/starstruct/elementvariable.py
@@ -178,6 +178,9 @@ class ElementVariable(Element):
         if not isinstance(iterator, list):
             iterator = [iterator]
 
+        iterator = [item if not hasattr(item, '_asdict') else item._asdict()
+                    for item in iterator]
+
         if self.variable_repeat:
             if self.object_length:
                 ret = [self.format.pack(dict(elem)) if elem else self.format.pack({})

--- a/starstruct/message.py
+++ b/starstruct/message.py
@@ -119,7 +119,7 @@ class Message(object):
         # Handle a positional dictionary argument as well as the more generic kwargs
         if obj and isinstance(obj, dict):
             kwargs = obj
-        return b''.join([elem.pack(kwargs) for elem in self._elements.values()])
+        return b''.join(elem.pack(kwargs) for elem in self._elements.values())
 
     def unpack_partial(self, buf):
         """

--- a/starstruct/modes.py
+++ b/starstruct/modes.py
@@ -17,9 +17,9 @@ class Mode(enum.Enum):
         Convert a Mode to a byteorder string such as required by the
         to_bytes() or from_bytes() functions.
         """
-        if self == self.Native:
+        if self == Mode.Native:
             return sys.byteorder
-        elif self == self.Little:
+        elif self == Mode.Little:
             return 'little'
         else:  # Big or Network
             return 'big'

--- a/starstruct/startuple.py
+++ b/starstruct/startuple.py
@@ -32,6 +32,8 @@ def StarTuple(name, named_fields, elements):
 
     named_tuple = collections.namedtuple(name, named_fields)
 
+    # TODO: Auto update and replace!
+
     def this_pack(self):
         packed = bytes()
         for _, value in self._elements.items():

--- a/starstruct/tests/test_elementcallable.py
+++ b/starstruct/tests/test_elementcallable.py
@@ -26,6 +26,36 @@ class TestStarStruct(unittest.TestCase):
         ('z', 'H'),
     ])
 
+    def test_single_element_with_set(self):
+        TestStruct = Message('TestStruct', [
+            ('length_in_objects', 'H', 'vardata'),
+            ('vardata', self.VarTest, 'length_in_objects'),
+        ])
+
+        CRCedMessage = Message('CRCedMessage', [
+            ('data', TestStruct),
+            ('function_data', 'I', {
+                (crc32, b'data')
+            }),
+        ])
+
+        test_data = {
+            'data': {
+                'length_in_objects': 2,
+                'vardata': [
+                    {'x': 1, 'y': 2},
+                    {'x': 3, 'y': 4},
+                ],
+            },
+        }
+
+        made = CRCedMessage.make(test_data)
+        # assert len(made) == 5
+        assert len(made.data.vardata) == 2
+        assert made.data.vardata[0].x == 1
+        assert made.data.vardata[0].y == 2
+        assert made.function_data == crc32(TestStruct.pack(test_data['data']))
+
     def test_single_element_2(self):
         TestStruct = Message('TestStruct', [
             ('length_in_objects', 'H', 'vardata'),
@@ -34,7 +64,11 @@ class TestStarStruct(unittest.TestCase):
 
         CRCedMessage = Message('CRCedMessage', [
             ('data', TestStruct),
-            ('function_data', 'I', crc32, [b'data']),
+            ('function_data', 'I', {
+                'pack': (crc32, b'data'),
+                'make': (crc32, b'data'),
+                'unpack': (crc32, b'data'),
+            }),
         ])
 
         test_data = {
@@ -66,7 +100,9 @@ class TestStarStruct(unittest.TestCase):
         CRCedMessage = Message('TestStruct', [
             ('length_in_objects', 'H', 'vardata'),
             ('vardata', self.VarTest, 'length_in_objects'),
-            ('function_data', 'I', crc32_wrapper, [b'length_in_objects', b'vardata']),
+            ('function_data', 'I', {
+                (crc32_wrapper, b'length_in_objects', b'vardata')
+            }),
         ])
 
         test_data = {
@@ -92,7 +128,9 @@ class TestStarStruct(unittest.TestCase):
         AdderMessage = Message('AdderMessage', [
             ('item_a', 'H'),
             ('item_b', 'B'),
-            ('function_data', 'I', adder, ['item_a', 'item_b']),
+            ('function_data', 'I', {
+                (adder, 'item_a', 'item_b')
+            }),
         ])
 
         test_data = {
@@ -117,7 +155,9 @@ class TestStarStruct(unittest.TestCase):
             ('item_d', 'B'),
             ('item_e', 'B'),
             # Note, there is no item 'e' in the list of arguments
-            ('function_data', 'I', adder, ['item_a', 'item_b', 'item_c', 'item_d']),
+            ('function_data', 'I', {
+                (adder, 'item_a', 'item_b', 'item_c', 'item_d')
+            }),
         ])
 
         # Test getting the correct result
@@ -182,7 +222,9 @@ class TestStarStruct(unittest.TestCase):
             ('item_d', 'B'),
             ('item_e', 'B'),
             # Note, there is no item 'e' in the list of arguments
-            ('function_data', 'I', adder, ['item_a', 'item_b', 'item_c', 'item_d'], False),
+            ('function_data', 'I', {
+                (adder, 'item_a', 'item_b', 'item_c', 'item_d')
+            }, False),
         ])
 
         # Test with incorrect result
@@ -209,7 +251,9 @@ class TestStarStruct(unittest.TestCase):
             ('item_d', 'B'),
             ('item_e', 'B'),
             # Note, there is no item 'e' in the list of arguments
-            ('function_data', 'I', adder, ['item_a', 'item_b', 'item_c', 'item_d']),
+            ('function_data', 'I', {
+                (adder, 'item_a', 'item_b', 'item_c', 'item_d')
+            }),
         ])
 
         # Test getting the correct result
@@ -248,7 +292,9 @@ class TestStarStruct(unittest.TestCase):
             ('item_d', 'B'),
             ('item_e', 'B'),
             # Note, there is no item 'e' in the list of arguments
-            ('function_data', 'I', adder, ['item_a', 'item_b', 'item_c', 'item_d'], False),
+            ('function_data', 'I', {
+                (adder, 'item_a', 'item_b', 'item_c', 'item_d')
+            }, False),
         ])
 
         # Test getting the correct result

--- a/starstruct/tests/test_elementnone.py
+++ b/starstruct/tests/test_elementnone.py
@@ -7,6 +7,7 @@ from hashlib import md5
 
 from starstruct.message import Message
 
+
 class TestStarStructNone(unittest.TestCase):
     """StarStruct module tests"""
 

--- a/starstruct/tests/test_elementnone.py
+++ b/starstruct/tests/test_elementnone.py
@@ -2,6 +2,7 @@
 
 """Tests for the starstruct class"""
 
+import struct
 import unittest
 from hashlib import md5
 
@@ -19,6 +20,10 @@ class TestStarStructNone(unittest.TestCase):
     def test_single_element_2(self):
         def pseudo_salted_md5(salt, original):
             temp_md5 = md5(original)
+
+            if salt is None:
+                salt = b''
+
             return md5(salt + temp_md5.digest()).digest()
 
         TestStruct = Message('TestStruct', [
@@ -29,7 +34,7 @@ class TestStarStructNone(unittest.TestCase):
         CRCedMessage = Message('CRCedMessage', [
             ('data', TestStruct),
             ('salted', None),
-            ('function_data', '16B', pseudo_salted_md5, ['salted', b'data']),
+            ('function_data', '16B', pseudo_salted_md5, ['salted', b'data'], False),
         ])
 
         test_data = {
@@ -52,3 +57,20 @@ class TestStarStructNone(unittest.TestCase):
         no_data = made.pack()
         regular = CRCedMessage.pack(**test_data)
         assert regular == no_data
+
+        # Show that there's no room to have the random salter be packed
+        len_data = len(no_data) - 16
+        assert no_data[0:len_data] == struct.pack('HBBBB', 2, 1, 2, 3, 4)
+        assert md5(
+            b'random_salter' +
+            md5(no_data[0:len_data]).digest()
+        ).digest() == no_data[len_data:]
+
+        unpacked = CRCedMessage.unpack(no_data)
+
+        assert unpacked.salted is None
+
+        # TEMP
+        new = unpacked._replace(**{'salted': b'random_salter'})
+        assert new.salted == b'random_salter'
+        # print(new._asdict())

--- a/starstruct/tests/test_elementnone.py
+++ b/starstruct/tests/test_elementnone.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+"""Tests for the starstruct class"""
+
+import unittest
+from hashlib import md5
+
+from starstruct.message import Message
+
+class TestStarStructNone(unittest.TestCase):
+    """StarStruct module tests"""
+
+    VarTest = Message('VarTest', [
+        ('x', 'B'),
+        ('y', 'B'),
+    ])
+
+    def test_single_element_2(self):
+        def pseudo_salted_md5(salt, original):
+            temp_md5 = md5(original)
+            return md5(salt + temp_md5.digest()).digest()
+
+        TestStruct = Message('TestStruct', [
+            ('length_in_objects', 'H', 'vardata'),
+            ('vardata', self.VarTest, 'length_in_objects'),
+        ])
+
+        CRCedMessage = Message('CRCedMessage', [
+            ('data', TestStruct),
+            ('salted', None),
+            ('function_data', '16B', pseudo_salted_md5, ['salted', b'data']),
+        ])
+
+        test_data = {
+            'data': {
+                'length_in_objects': 2,
+                'vardata': [
+                    {'x': 1, 'y': 2},
+                    {'x': 3, 'y': 4},
+                ],
+            },
+            'salted': b'random_salter',
+        }
+
+        made = CRCedMessage.make(test_data)
+        # assert len(made) == 5
+        assert len(made.data.vardata) == 2
+        assert made.data.vardata[0].x == 1
+        assert made.data.vardata[0].y == 2
+
+        no_data = made.pack()
+        regular = CRCedMessage.pack(**test_data)
+        assert regular == no_data

--- a/starstruct/tests/test_elementnone.py
+++ b/starstruct/tests/test_elementnone.py
@@ -11,13 +11,14 @@ from starstruct.message import Message
 
 class TestStarStructNone(unittest.TestCase):
     """StarStruct module tests"""
+    # TODO: Clean up these tests, change names, and move a bunch of the items to a helper function
 
     VarTest = Message('VarTest', [
         ('x', 'B'),
         ('y', 'B'),
     ])
 
-    def test_single_element_2(self):
+    def test_single_element_1(self):
         def pseudo_salted_md5(salt, original):
             temp_md5 = md5(original)
 
@@ -27,7 +28,7 @@ class TestStarStructNone(unittest.TestCase):
             return md5(salt + temp_md5.digest()).digest()
 
         def pack_salt(data):
-            return md5(data).digest()
+            return b''.join(item.to_bytes(1, 'little') for item in data)
 
         TestStruct = Message('TestStruct', [
             ('length_in_objects', 'H', 'vardata'),
@@ -40,7 +41,7 @@ class TestStarStructNone(unittest.TestCase):
             ('function_data', '16B', {
                 'make': (pseudo_salted_md5, 'salted', b'data'),
                 'pack': (pseudo_salted_md5, 'salted', b'data'),
-                'unpack': (pack_salt, b'data'),
+                'unpack': (pack_salt, 'function_data'),
             }, False),
         ])
 
@@ -56,7 +57,6 @@ class TestStarStructNone(unittest.TestCase):
         }
 
         made = CRCedMessage.make(test_data)
-        # assert len(made) == 5
         assert len(made.data.vardata) == 2
         assert made.data.vardata[0].x == 1
         assert made.data.vardata[0].y == 2
@@ -82,3 +82,281 @@ class TestStarStructNone(unittest.TestCase):
         new = unpacked._replace(**{'salted': b'random_salter'})
         assert new.salted == b'random_salter'
         # print(new._asdict())
+
+    def test_single_element_2(self):
+        def pseudo_salted_md5(salt, original):
+            temp_md5 = md5(original)
+
+            if salt is None:
+                salt = b''
+
+            return md5(salt + temp_md5.digest()).digest()
+
+        def do_nothing(data):
+            return data
+
+        TestStruct = Message('TestStruct', [
+            ('length_in_objects', 'H', 'vardata'),
+            ('vardata', self.VarTest, 'length_in_objects'),
+        ])
+
+        CRCedMessage = Message('CRCedMessage', [
+            ('data', TestStruct),
+            ('salted', None),
+            ('function_data', '16B', {
+                'make': (pseudo_salted_md5, 'salted', b'data'),
+                'pack': (pseudo_salted_md5, 'salted', b'data'),
+                'unpack': (do_nothing, 'function_data'),
+            }, False),
+        ])
+
+        test_data = {
+            'data': {
+                'length_in_objects': 2,
+                'vardata': [
+                    {'x': 1, 'y': 2},
+                    {'x': 3, 'y': 4},
+                ],
+            },
+            'salted': b'random_salter',
+        }
+
+        made = CRCedMessage.make(test_data)
+        assert len(made.data.vardata) == 2
+        assert made.data.vardata[0].x == 1
+        assert made.data.vardata[0].y == 2
+
+        no_data = made.pack()
+        regular = CRCedMessage.pack(**test_data)
+        assert regular == no_data
+
+        # Show that there's no room to have the random salter be packed
+        len_data = len(no_data) - 16
+        assert no_data[0:len_data] == struct.pack('HBBBB', 2, 1, 2, 3, 4)
+        assert md5(
+            b'random_salter' +
+            md5(no_data[0:len_data]).digest()
+        ).digest() == no_data[len_data:]
+
+        unpacked = CRCedMessage.unpack(no_data)
+
+        assert unpacked.salted is None
+        # This is non symmetric for this test, so we can't just check based on the made item
+        assert unpacked.function_data == (157, 38, 247, 245, 5, 71, 43, 227, 80, 44, 10, 243, 48, 248, 163, 207)
+
+        # TEMP
+        new = unpacked._replace(**{'salted': b'random_salter'})
+        assert new.salted == b'random_salter'
+        # print(new._asdict())
+
+    def test_single_element_3(self):
+        def pseudo_salted_md5(salt, original):
+            temp_md5 = md5(original)
+
+            if salt is None:
+                salt = b''
+
+            return md5(salt + temp_md5.digest()).digest()
+
+        def double(data):
+            return [item * 2 for item in data]
+
+        TestStruct = Message('TestStruct', [
+            ('length_in_objects', 'H', 'vardata'),
+            ('vardata', self.VarTest, 'length_in_objects'),
+        ])
+
+        CRCedMessage = Message('CRCedMessage', [
+            ('data', TestStruct),
+            ('salted', None),
+            ('function_data', '16B', {
+                'make': (pseudo_salted_md5, 'salted', b'data'),
+                'pack': (pseudo_salted_md5, 'salted', b'data'),
+                'unpack': (double, 'function_data'),
+            }, False),
+        ])
+
+        test_data = {
+            'data': {
+                'length_in_objects': 2,
+                'vardata': [
+                    {'x': 1, 'y': 2},
+                    {'x': 3, 'y': 4},
+                ],
+            },
+            'salted': b'random_salter',
+        }
+
+        made = CRCedMessage.make(test_data)
+        assert len(made.data.vardata) == 2
+        assert made.data.vardata[0].x == 1
+        assert made.data.vardata[0].y == 2
+
+        no_data = made.pack()
+        regular = CRCedMessage.pack(**test_data)
+        assert regular == no_data
+
+        # Show that there's no room to have the random salter be packed
+        len_data = len(no_data) - 16
+        assert no_data[0:len_data] == struct.pack('HBBBB', 2, 1, 2, 3, 4)
+        assert md5(
+            b'random_salter' +
+            md5(no_data[0:len_data]).digest()
+        ).digest() == no_data[len_data:]
+
+        unpacked = CRCedMessage.unpack(no_data)
+
+        assert unpacked.salted is None
+        # This is non symmetric for this test, so we can't just check based on the made item
+        assert unpacked.function_data == [314, 76, 494, 490, 10, 142, 86, 454, 160, 88, 20, 486, 96, 496, 326, 414]
+
+    def test_single_element_4(self):
+        def pseudo_salted_md5(salt, original):
+            temp_md5 = md5(original)
+
+            if salt is None:
+                salt = b''
+
+            return md5(salt + temp_md5.digest()).digest()
+
+        def double(data):
+            return [item * 2 for item in data]
+
+        TestStruct = Message('TestStruct', [
+            ('length_in_objects', 'H', 'vardata'),
+            ('vardata', self.VarTest, 'length_in_objects'),
+        ])
+
+        # This one has nothing to do with the original packed message
+        CRCedMessage = Message('CRCedMessage', [
+            ('data', TestStruct),
+            ('salted', None),
+            ('function_data', '16B', {
+                'make': (pseudo_salted_md5, 'salted', b'data'),
+                'pack': (pseudo_salted_md5, 'salted', b'data'),
+                'unpack': (double, b'data'),
+            }, False),
+        ])
+
+        test_data = {
+            'data': {
+                'length_in_objects': 2,
+                'vardata': [
+                    {'x': 1, 'y': 2},
+                    {'x': 3, 'y': 4},
+                ],
+            },
+            'salted': b'random_salter',
+        }
+
+        made = CRCedMessage.make(test_data)
+        assert len(made.data.vardata) == 2
+        assert made.data.vardata[0].x == 1
+        assert made.data.vardata[0].y == 2
+
+        no_data = made.pack()
+        regular = CRCedMessage.pack(**test_data)
+        assert regular == no_data
+
+        # Show that there's no room to have the random salter be packed
+        len_data = len(no_data) - 16
+        assert no_data[0:len_data] == struct.pack('HBBBB', 2, 1, 2, 3, 4)
+        assert md5(
+            b'random_salter' +
+            md5(no_data[0:len_data]).digest()
+        ).digest() == no_data[len_data:]
+
+        unpacked = CRCedMessage.unpack(no_data)
+
+        assert unpacked.salted is None
+        # This is non symmetric for this test, so we can't just check based on the made item
+        assert unpacked.function_data == [4, 0, 2, 4, 6, 8]
+
+    def test_nounpack_function(self):
+        def pseudo_salted_md5(salt, original):
+            temp_md5 = md5(original)
+
+            if salt is None:
+                salt = b''
+
+            return md5(salt + temp_md5.digest()).digest()
+
+        TestStruct = Message('TestStruct', [
+            ('length_in_objects', 'H', 'vardata'),
+            ('vardata', self.VarTest, 'length_in_objects'),
+        ])
+
+        # This one has nothing to do with the original packed message
+        ExplicitNone = Message('Explicit', [
+            ('data', TestStruct),
+            ('salted', None),
+            ('function_data', '16B', {
+                'make': (pseudo_salted_md5, 'salted', b'data'),
+                'pack': (pseudo_salted_md5, 'salted', b'data'),
+                'unpack': (None, ),
+            }, False),
+        ])
+
+        ImplicitNone = Message('Implicit', [
+            ('data', TestStruct),
+            ('salted', None),
+            ('function_data', '16B', {
+                'make': (pseudo_salted_md5, 'salted', b'data'),
+                'pack': (pseudo_salted_md5, 'salted', b'data'),
+            }, False),
+        ])
+
+        test_data = {
+            'data': {
+                'length_in_objects': 2,
+                'vardata': [
+                    {'x': 1, 'y': 2},
+                    {'x': 3, 'y': 4},
+                ],
+            },
+            'salted': b'random_salter',
+        }
+
+        made = ExplicitNone.make(test_data)
+        assert len(made.data.vardata) == 2
+        assert made.data.vardata[0].x == 1
+        assert made.data.vardata[0].y == 2
+
+        no_data = made.pack()
+        regular = ExplicitNone.pack(**test_data)
+        assert regular == no_data
+
+        # Show that there's no room to have the random salter be packed
+        len_data = len(no_data) - 16
+        assert no_data[0:len_data] == struct.pack('HBBBB', 2, 1, 2, 3, 4)
+        assert md5(
+            b'random_salter' +
+            md5(no_data[0:len_data]).digest()
+        ).digest() == no_data[len_data:]
+
+        unpacked = ExplicitNone.unpack(no_data)
+
+        assert unpacked.salted is None
+        assert unpacked.function_data == (157, 38, 247, 245, 5, 71, 43, 227, 80, 44, 10, 243, 48, 248, 163, 207)
+
+        made = ImplicitNone.make(test_data)
+        assert len(made.data.vardata) == 2
+        assert made.data.vardata[0].x == 1
+        assert made.data.vardata[0].y == 2
+
+        no_data = made.pack()
+        regular = ImplicitNone.pack(**test_data)
+        assert regular == no_data
+
+        # Show that there's no room to have the random salter be packed
+        len_data = len(no_data) - 16
+        assert no_data[0:len_data] == struct.pack('HBBBB', 2, 1, 2, 3, 4)
+        assert md5(
+            b'random_salter' +
+            md5(no_data[0:len_data]).digest()
+        ).digest() == no_data[len_data:]
+
+        unpacked = ImplicitNone.unpack(no_data)
+
+        assert unpacked.salted is None
+        assert unpacked.function_data == (157, 38, 247, 245, 5, 71, 43, 227, 80, 44, 10, 243, 48, 248, 163, 207)


### PR DESCRIPTION
Add an element none.

This can be used for sending arguments to functions.

Maybe more later, but I thought it was a cool idea for now.

Also lets you specify information without having to have it get packed. Probably will find some bugs when we unpack or have some weird situations like that.